### PR TITLE
AGENT-172. template-launcher configuration should have metrics enable…

### DIFF
--- a/template-launcher.conf
+++ b/template-launcher.conf
@@ -82,9 +82,10 @@ fetcher-request-timeout-seconds = 300
 ###
 [metrics]
 
-enabled = false
+enabled = true
 
-metrics-collection-frequency = 6000
+# Metrics collection Frequency. Default 30sec
+metrics-collection-frequency = 30000
 
 
 ###


### PR DESCRIPTION
…d by default

- also made default poll interval 30sec to enable faster user feedback

Signed-off-by: Keith Burns <keith@streamsets.com>